### PR TITLE
Optionally declare wallet address for transfer request payload

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,7 @@ export type TransferRequestBody = {
   cryptoType: CryptoType
   amount: string
   fiatAccountId: string
+  wallet?: string
 }
 
 // Response body for POST /transfer/in and POST /transfer/out

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ export type TransferRequestBody = {
   cryptoType: CryptoType
   amount: string
   fiatAccountId: string
-  wallet?: string
+  destinationAddress?: string
 }
 
 // Response body for POST /transfer/in and POST /transfer/out


### PR DESCRIPTION
In cases where a wallet is a smart-contract, the address linked to their fiatConnect account will be their EOA rather than their wallet, as they will sign the jwt token with their private key for user auth.  In this case when a user goes to initiate a transfer, it will transfer the funds to their EOA rather than their smart contract wallet, and if it is a transfer out the provider will be looking for transfers _from_ the EOA rather than the smart wallet.  This can be handled by the ui, but it is one additional txn for the user to sign.

The wallet field could default to the address of the fiatConnect account, so if not necessary it would not need to be provided.