### PR TITLE
feat(kyc): Add support for PersonalDataAndDocuments KYC schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.0.1](https://github.com/fiatconnect/fiatconnect-types/compare/v1.0.0...v1.0.1) (2022-03-11)
+
 ### 1.0.0 (2022-03-01)
 
 Initial version of type definitions for the FiatConnect SDK and FiatConnect API implementations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.0.2](https://github.com/fiatconnect/fiatconnect-types/compare/v1.0.0...v1.0.2) (2022-03-11)
+
 ### [1.0.1](https://github.com/fiatconnect/fiatconnect-types/compare/v1.0.0...v1.0.1) (2022-03-11)
 
 ### 1.0.0 (2022-03-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### [1.0.2](https://github.com/fiatconnect/fiatconnect-types/compare/v1.0.0...v1.0.2) (2022-03-11)
 
-### [1.0.1](https://github.com/fiatconnect/fiatconnect-types/compare/v1.0.0...v1.0.1) (2022-03-11)
+Adds support for `PersonalDataAndDocumentsKyc` KYC schema, and removes the mock KYC schema `MockNameAndAddressKyc`.
 
 ### 1.0.0 (2022-03-01)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiatconnect/fiatconnect-types",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Types used in the FiatConnect specification. Offered as standalone module for payment providers and wallets to both use for FiatConnect APIs and integrations.",
   "scripts": {
     "prepublish": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiatconnect/fiatconnect-types",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Types used in the FiatConnect specification. Offered as standalone module for payment providers and wallets to both use for FiatConnect APIs and integrations.",
   "scripts": {
     "prepublish": "tsc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,7 +237,7 @@ export enum CryptoType {
 }
 
 export enum KycSchema {
-  MockNameAndAddress = 'MockNameAndAddress',
+  PersonalDataAndDocuments = 'PersonalDataAndDocuments',
 }
 
 export enum FiatAccountSchema {
@@ -258,17 +258,24 @@ export interface MockCheckingAccount {
   routingNumber: string
 }
 
-export interface MockNameAndAddressKyc {
+export interface PersonalDataAndDocumentsKyc {
   firstName: string
+  middleName?: string
   lastName: string
-  address: PostalAddress
-}
-
-export interface PostalAddress {
-  address1: string
-  address2?: string
-  city: string
-  region: string // in the US this means state
-  postalCode: string
-  isoCountryCode: string
+  dateOfBirth: {
+    day: string
+    month: string
+    year: string
+  }
+  address: {
+    address1: string
+    address2?: string
+    isoCountryCode: string
+    isoRegionCode: string
+    city: string
+    postalCode?: string
+  }
+  phoneNumber: string
+  selfieDocument: string
+  identificationDocument: string
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -258,6 +258,7 @@ export interface MockCheckingAccount {
   routingNumber: string
 }
 
+// https://github.com/fiatconnect/specification/blob/5929f7ea8ca99796608e89a9c8da4c1033dacf05/fiatconnect-api.md#728-personaldataanddocuments
 export interface PersonalDataAndDocumentsKyc {
   firstName: string
   middleName?: string


### PR DESCRIPTION
Adds support for the PersonalDataAndDocuments KYC schema, required by PayChant. See [here](https://github.com/fiatconnect/specification/blob/main/fiatconnect-api.md#728-personaldataanddocuments) for the related spec.