### PR TITLE
chore(build): Fix an issue with KYC schema being exported under the wrong name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### [1.0.3](https://github.com/fiatconnect/fiatconnect-types/compare/v1.0.0...v1.0.3) (2022-03-11)
 
-
-### Features
-
-* **kyc:** Add support for PersonalDataAndDocuments KYC schema ([#5](https://github.com/fiatconnect/fiatconnect-types/issues/5)) ([5d529f0](https://github.com/fiatconnect/fiatconnect-types/commit/5d529f07769ef643ff265a7cfb4849d7d71e61fd))
+Fix an issue with PersonalDataAndDocumentsKyc being exported under the wrong name.
 
 ### [1.0.2](https://github.com/fiatconnect/fiatconnect-types/compare/v1.0.0...v1.0.2) (2022-03-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.0.3](https://github.com/fiatconnect/fiatconnect-types/compare/v1.0.0...v1.0.3) (2022-03-11)
+
+
+### Features
+
+* **kyc:** Add support for PersonalDataAndDocuments KYC schema ([#5](https://github.com/fiatconnect/fiatconnect-types/issues/5)) ([5d529f0](https://github.com/fiatconnect/fiatconnect-types/commit/5d529f07769ef643ff265a7cfb4849d7d71e61fd))
+
 ### [1.0.2](https://github.com/fiatconnect/fiatconnect-types/compare/v1.0.0...v1.0.2) (2022-03-11)
 
 Adds support for `PersonalDataAndDocumentsKyc` KYC schema, and removes the mock KYC schema `MockNameAndAddressKyc`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiatconnect/fiatconnect-types",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Types used in the FiatConnect specification. Offered as standalone module for payment providers and wallets to both use for FiatConnect APIs and integrations.",
   "scripts": {
     "prepublish": "tsc",


### PR DESCRIPTION
The distribution for v1.0.2 was published out-of-sync with the repo state, and was exporting `PersonalDataAndDocumentsKyc` as `PersonalDataAndDocuments` incorrectly. (I transpiled to JS when the PR was still being worked on, and forgot to build again once the PR was merged/before deploying.) This PR is just to update the changelog; no actual code changes are required.