### PR TITLE
chore(release): Fix build issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [2.0.0](https://github.com/fiatconnect/fiatconnect-types/compare/v1.0.0...v2.0.0) (2022-03-11)
-
-
-### Features
-
-* **kyc:** Add support for PersonalDataAndDocuments KYC schema ([#5](https://github.com/fiatconnect/fiatconnect-types/issues/5)) ([5d529f0](https://github.com/fiatconnect/fiatconnect-types/commit/5d529f07769ef643ff265a7cfb4849d7d71e61fd))
-
-### [1.0.2](https://github.com/fiatconnect/fiatconnect-types/compare/v1.0.0...v1.0.2) (2022-03-11)
+### 2.0.0 (2022-03-11)
 
 Adds support for `PersonalDataAndDocumentsKyc` KYC schema, and removes the mock KYC schema `MockNameAndAddressKyc`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.0.0](https://github.com/fiatconnect/fiatconnect-types/compare/v1.0.0...v2.0.0) (2022-03-11)
+
+
+### Features
+
+* **kyc:** Add support for PersonalDataAndDocuments KYC schema ([#5](https://github.com/fiatconnect/fiatconnect-types/issues/5)) ([5d529f0](https://github.com/fiatconnect/fiatconnect-types/commit/5d529f07769ef643ff265a7cfb4849d7d71e61fd))
+
 ### [1.0.2](https://github.com/fiatconnect/fiatconnect-types/compare/v1.0.0...v1.0.2) (2022-03-11)
 
 Adds support for `PersonalDataAndDocumentsKyc` KYC schema, and removes the mock KYC schema `MockNameAndAddressKyc`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiatconnect/fiatconnect-types",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Types used in the FiatConnect specification. Offered as standalone module for payment providers and wallets to both use for FiatConnect APIs and integrations.",
   "scripts": {
     "prepublish": "tsc",


### PR DESCRIPTION
See #6. I've unpublished v1.0.2 from NPM. Once this is merged, I'll republish under v2.0.0, which is semantically correct, since we've removed a mock KYC type, so this update should be categorized as breaking.