### PR TITLE
feat(accounts): update params for fiat accounts endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,9 +114,9 @@ export type KycStatusResponse = {
 */
 
 // Request body for POST /accounts/
-export type PostFiatAccountRequestBody = {
-  fiatAccountSchema: FiatAccountSchema
-  data: FiatAccountSchemaData
+export type PostFiatAccountRequestBody<T extends FiatAccountSchema> = {
+  fiatAccountSchema: T
+  data: FiatAccountSchemas[T]
 }
 
 // Path parameters for DELETE /accounts/:fiatAccountId
@@ -373,13 +373,14 @@ export enum SupportedOperatorEnum {
   WAVE = 'WAVE',
 }
 
-// Union of all supported fiat account schemas. List must be manually updated
-export type FiatAccountSchemaData =
-  | AccountNumber
-  | MobileMoney
-  | DuniaWallet
-  | IBANNumber
-  | IFSCAccount
+// Map of all supported fiat account schemas to the corresponding schema type. List must be manually updated
+export type FiatAccountSchemas = {
+  [FiatAccountSchema.AccountNumber]: AccountNumber
+  [FiatAccountSchema.MobileMoney]: MobileMoney
+  [FiatAccountSchema.DuniaWallet]: DuniaWallet
+  [FiatAccountSchema.IBANNumber]: IBANNumber
+  [FiatAccountSchema.IFSCAccount]: IFSCAccount
+}
 
 // https://github.com/fiatconnect/specification/blob/5929f7ea8ca99796608e89a9c8da4c1033dacf05/fiatconnect-api.md#728-personaldataanddocuments
 export interface PersonalDataAndDocumentsKyc {

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,23 +113,24 @@ export type KycStatusResponse = {
 / Fiat Account Endpoint Types
 */
 
-// Path parameters for POST /accounts/:fiatAccountSchema
-export type AddFiatAccountRequestParams = {
+// Request body for POST /accounts/
+export type PostFiatAccountRequestBody = {
   fiatAccountSchema: FiatAccountSchema
+  data: FiatAccountSchemaData
 }
 
-// Path parameters for DELETE /accounnt/:fiatAccountId
+// Path parameters for DELETE /accounts/:fiatAccountId
 export type DeleteFiatAccountRequestParams = {
   fiatAccountId: FiatAccountId
 }
 
-// Response body for GET /accounts/:fiatAccountSchema
+// Response body for GET /accounts/
 export type GetFiatAccountsResponse = Partial<
   Record<FiatAccountType, ObfuscatedFiatAccountData[]>
 >
 
-// Response body for POST /accounts/:fiatAccountSchema
-export type AddFiatAccountResponse = ObfuscatedFiatAccountData
+// Response body for POST /accounts/
+export type PostFiatAccountResponse = ObfuscatedFiatAccountData
 
 // Helper type. Generic representation of a fiat account, with personal information stripped.
 export type ObfuscatedFiatAccountData = {
@@ -371,6 +372,14 @@ export enum SupportedOperatorEnum {
   MTN = 'MTN',
   WAVE = 'WAVE',
 }
+
+// Union of all supported fiat account schemas. List must be manually updated
+export type FiatAccountSchemaData =
+  | AccountNumber
+  | MobileMoney
+  | DuniaWallet
+  | IBANNumber
+  | IFSCAccount
 
 // https://github.com/fiatconnect/specification/blob/5929f7ea8ca99796608e89a9c8da4c1033dacf05/fiatconnect-api.md#728-personaldataanddocuments
 export interface PersonalDataAndDocumentsKyc {

--- a/src/index.ts
+++ b/src/index.ts
@@ -336,30 +336,31 @@ interface RequiredFiatAccountSchemaFields {
   fiatAccountType: FiatAccountType
 }
 
-export type AccountNumber = RequiredFiatAccountSchemaFields & {
+type AccountNumber = RequiredFiatAccountSchemaFields & {
   accountNumber: string
   country: string
   fiatAccountType: FiatAccountType.BankAccount
 }
-export type MobileMoney = RequiredFiatAccountSchemaFields & {
+
+type MobileMoney = RequiredFiatAccountSchemaFields & {
   mobile: string
   country: string
   operator: SupportedOperatorEnum
   fiatAccountType: FiatAccountType.MobileMoney
 }
 
-export type DuniaWallet = RequiredFiatAccountSchemaFields & {
+type DuniaWallet = RequiredFiatAccountSchemaFields & {
   mobile: string
   fiatAccountType: FiatAccountType.DuniaWallet
 }
 
-export type IBANNumber = RequiredFiatAccountSchemaFields & {
+type IBANNumber = RequiredFiatAccountSchemaFields & {
   iban: string
   country: string
   fiatAccountType: FiatAccountType.BankAccount
 }
 
-export type IFSCAccount = RequiredFiatAccountSchemaFields & {
+type IFSCAccount = RequiredFiatAccountSchemaFields & {
   ifsc: string
   accountNumber: string
   country: string


### PR DESCRIPTION
BREAKING CHANGE: 
- Removed query params for POST /accounts and added body. Also renamed `Add` to `Post`.
- Export map of fiat account schemas instead of individual schemas

For https://github.com/fiatconnect/specification/commit/df6ff3dbc7d1422bbcef85515d58bc357963711d