### PR TITLE
fix(KYC): Prefix KYC statuses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -199,11 +199,11 @@ export enum TransferStatus {
 }
 
 export enum KycStatus {
-  NotCreated = 'NotCreated',
-  Pending = 'Pending',
-  Approved = 'Approved',
-  Denied = 'Denied',
-  Expired = 'Expired',
+  KycNotCreated = 'KycNotCreated',
+  KycPending = 'KycPending',
+  KycApproved = 'KycApproved',
+  KycDenied = 'KycDenied',
+  KycExpired = 'KycExpired',
 }
 
 export enum FeeType {


### PR DESCRIPTION
The KYC status enum currently does not have the `'Kyc'` prefix in front of each status, which differs from the [expectation in the spec](https://github.com/fiatconnect/specification/blob/main/fiatconnect-api.md#811-kycstatusenum).