### PR TITLE
fix(webhook): ensure event type and payload matches

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -223,26 +223,22 @@ export enum WebhookEventType {
   TransferOutStatusEvent = 'TransferOutStatusEvent',
 }
 
-export type WebhookRequestBody = {
-  eventType: WebhookEventType
-  provider: string
-  eventId: string
-  accountAddress: string
-}
-
-export type WebhookKycStatusRequestBody = WebhookRequestBody & {
-  payload: {
+type WebhookEventPayload = {
+  [WebhookEventType.KycStatusEvent]: {
     kycSchema: KycSchema
     kycStatus: KycStatus
   }
+  [WebhookEventType.TransferInStatusEvent]: TransferStatusResponse
+  [WebhookEventType.TransferOutStatusEvent]: TransferStatusResponse
 }
 
-export type WebhookTransferInStatusRequestBody = WebhookRequestBody & {
-  payload: TransferStatusResponse
+export type WebhookRequestBody<T extends WebhookEventType> = {
+  eventType: T
+  provider: string
+  eventId: string
+  accountAddress: string
+  payload: WebhookEventPayload[T]
 }
-
-export type WebhookTransferOutStatusRequestBody =
-  WebhookTransferInStatusRequestBody
 
 // Errors returned by FiatConnect endpoints
 export enum FiatConnectError {


### PR DESCRIPTION
The current types allow any event type value for a specific body. E.g., `WebhookKycStatusRequestBody` could have `TransferOutStatusEvent` as event type. This ensures payload matches the event type.