### PR TITLE
fix(webhook): add timestamp

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -238,6 +238,7 @@ export type WebhookRequestBody<T extends WebhookEventType> = {
   eventType: T
   provider: string
   eventId: string
+  timestamp: string
   address: string
   payload: WebhookEventPayload[T]
 }


### PR DESCRIPTION
timestamp field was missing from the webhook request