### PR TITLE
chore(cd): switched to using personal access token for CD

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -57,6 +57,6 @@ jobs:
         run: yarn prepublish
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn publish


### PR DESCRIPTION
semantic-release docs left it somewhat unclear whether we'd need this, but I think we do because of how GH actions works now (as opposed to when the semantic-release docs were written) and maybe (also?) due to our branch protection rules

(the current workflow fails on the NPM publish step, see [here](https://github.com/fiatconnect/fiatconnect-types/runs/8116340437?check_suite_focus=true))