### PR TITLE
chore(cd): avoiding 'yarn publish' (has special meaning with yarn)

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -59,4 +59,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: yarn publish
+        run: yarn release

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "typecheck": "tsc",
     "prepublish": "rm -rf dist && tsc",
-    "publish": "npx semantic-release",
+    "release": "npx semantic-release",
     "lint": "eslint --ext=.tsx,.ts src/",
     "format:check": "prettier --check .",
     "format": "prettier --loglevel error --write ."


### PR DESCRIPTION
turns out `yarn publish` tries to publish to the NPM registry, even if it's over-ridden in `package.json`. This isn't what I actually wanted-- was just trying to run `npx semantic-release`