### PR TITLE
chore(cd): use GITHUB_TOKEN instead of personal access token

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -57,6 +57,6 @@ jobs:
         run: yarn prepublish
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn release


### PR DESCRIPTION
more secure, works just as well for publishing tags and releases, and PAT doesn't actually get us anything extra due to branch protection rules