### PR TITLE
fix(webhooks): add Webhook prefix to webhook event types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -220,9 +220,9 @@ export enum FeeFrequency {
 
 // Types for request bodies sent from FiatConnect webhooks
 export enum WebhookEventType {
-  KycStatusEvent = 'KycStatusEvent',
-  TransferInStatusEvent = 'TransferInStatusEvent',
-  TransferOutStatusEvent = 'TransferOutStatusEvent',
+  KycStatusEvent = 'WebhookKycStatusEvent',
+  TransferInStatusEvent = 'WebhookTransferInStatusEvent',
+  TransferOutStatusEvent = 'WebhookTransferOutStatusEvent',
 }
 
 type WebhookEventPayload = {


### PR DESCRIPTION
to match spec [here](https://github.com/fiatconnect/specification/blob/main/fiatconnect-api.md#913-webhookeventtypeenum)