### PR TITLE
feat(quotes)!: Make address a required field when fetching quotes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export interface AuthRequestBody {
 export type QuoteRequestBody = {
   fiatType: FiatType
   cryptoType: CryptoType
+  address: string
   fiatAmount?: string
   cryptoAmount?: string
   country: string


### PR DESCRIPTION
See [here](https://github.com/fiatconnect/specification/blob/main/fiatconnect-api.md#341111-request-body). Address is actually a required field when fetching quotes, but we currently do not require nor even allow it as a parameter.

BREAKING CHANGE: New parameter required on quotes