### PR TITLE
fix(fiatAccount)!: remove supported operator enum

### DIFF
--- a/src/fiat-account.ts
+++ b/src/fiat-account.ts
@@ -41,16 +41,6 @@ export const pixKeyTypeEnumSchema = z.nativeEnum(PIXKeyTypeEnum, {
   description: 'pixKeyTypeEnumSchema',
 })
 
-export enum SupportedOperatorEnum {
-  ORANGE = 'ORANGE',
-  MOOV = 'MOOV',
-  MTN = 'MTN',
-  WAVE = 'WAVE',
-}
-export const supportedOperatorEnumSchema = z.nativeEnum(SupportedOperatorEnum, {
-  description: 'supportedOperatorEnumSchema',
-})
-
 const requiredFiatAccountSchemaFieldsSchema = z.object({
   accountName: z.string(),
   institutionName: z.string(),
@@ -128,7 +118,7 @@ export const mobileMoneySchema = requiredFiatAccountSchemaFieldsSchema.and(
     {
       mobile: z.string(),
       country: z.string(),
-      operator: supportedOperatorEnumSchema,
+      operator: z.string(),
       fiatAccountType: z.literal(FiatAccountType.MobileMoney),
     },
     { description: 'mobileMoneySchema' },


### PR DESCRIPTION
Currently, the Mobile Money account schema requires the operator to be a member of an enum of supported operators. The FiatConnect spec has [been changed](https://github.com/fiatconnect/specification/pull/88) to remove this and instead only require the operator to be a string. 

This PR updates the types repo to match the updated spec and is a part of [ACT-581](https://linear.app/valora/issue/ACT-581/update-fc-deps-to-account-for-mobile-money-spec-change).