### PR TITLE
InvalidQuote

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -24,6 +24,7 @@ export enum FiatConnectError {
   IssuedTooEarly = 'IssuedTooEarly',
   ExpirationTooLong = 'ExpirationTooLong',
   InvalidFiatAccount = 'InvalidFiatAccount',
+  InvalidQuote = 'InvalidQuote',
 }
 export const fiatConnectErrorSchema = z.nativeEnum(FiatConnectError, {
   description: 'fiatConnectErrorSchema',


### PR DESCRIPTION
- Add InvalidQuote as a possible FiatConnectError as required by the specification (https://github.com/fiatconnect/specification/blob/main/fiatconnect-api.md#3441323-invalidquote)