### PR TITLE
fix(enums): add missing error type and transfer status

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -24,6 +24,7 @@ export enum FiatConnectError {
   IssuedTooEarly = 'IssuedTooEarly',
   ExpirationTooLong = 'ExpirationTooLong',
   InvalidFiatAccount = 'InvalidFiatAccount',
+  InvalidQuote = 'InvalidQuote',
 }
 export const fiatConnectErrorSchema = z.nativeEnum(FiatConnectError, {
   description: 'fiatConnectErrorSchema',

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -13,6 +13,7 @@ export const transferTypeSchema = z.nativeEnum(TransferType, {
 export enum TransferStatus {
   TransferStarted = 'TransferStarted',
   TransferFiatFundsDebited = 'TransferFiatFundsDebited',
+  TransferReceivedFiatFunds = 'TransferReceivedFiatFunds',
   TransferSendingCryptoFunds = 'TransferSendingCryptoFunds',
   TransferAmlFailed = 'TransferAmlFailed',
   TransferReadyForUserToSendCryptoFunds = 'TransferReadyForUserToSendCryptoFunds',


### PR DESCRIPTION
- Added InvalidQuote as possibleError in FiatConnectErrors as required by the specification (https://github.com/fiatconnect/specification/blob/main/fiatconnect-api.md#3441323-invalidquote)
- Added TransferReceivedFiatFunds as possible TransferStatus as required by the specification (https://github.com/fiatconnect/specification/blob/main/fiatconnect-api.md#41-transfers-in)