### PR TITLE
Add support for new KYC schema

### DIFF
--- a/src/kyc.ts
+++ b/src/kyc.ts
@@ -29,13 +29,13 @@ export const kycSchemaSchema = z.nativeEnum(KycSchema, {
   description: 'kycSchemaSchema',
 })
 
-export enum KycDocumentType {
+export enum IdentificationDocumentType {
   IDC = 'IDC',
   PAS = 'PAS',
   DL = 'DL',
 }
-export const kycDocumentTypeSchema = z.nativeEnum(KycDocumentType, {
-  description: 'kycDocumentTypeSchema',
+export const IdentificationDocumentTypeSchema = z.nativeEnum(IdentificationDocumentType, {
+  description: 'IdentificationDocumentTypeSchema',
 })
 
 export const personalDataAndDocumentsKycSchema = z.object(
@@ -86,7 +86,7 @@ export const personalDataAndDocumentsDetailedKycSchema = z.object({
   phoneNumber: z.string(),
   email: z.string(),
   selfieDocument: z.string(),
-  identificationDocumentType: z.enum(['IDC', 'PAS', 'DL']),
+  identificationDocumentType: z.nativeEnum(IdentificationDocumentType),
   identificationDocumentFront: z.string(),
   identificationDocumentBack: z.string().optional(),
 })

--- a/src/kyc.ts
+++ b/src/kyc.ts
@@ -23,9 +23,19 @@ export const kycStatusSchema = z.nativeEnum(KycStatus, {
 // When adding new schemas be sure to also update kycSchemasSchema
 export enum KycSchema {
   PersonalDataAndDocuments = 'PersonalDataAndDocuments',
+  PersonalDataAndDocumentsDetailed = 'PersonalDataAndDocumentsDetailed'
 }
 export const kycSchemaSchema = z.nativeEnum(KycSchema, {
   description: 'kycSchemaSchema',
+})
+
+export enum KycDocumentType {
+  IDC = 'IDC',
+  PAS = 'PAS',
+  DL = 'DL'
+}
+export const kycDocumentTypeSchema = z.nativeEnum(KycDocumentType, {
+  description: 'kycDocumentTypeSchema'
 })
 
 export const personalDataAndDocumentsKycSchema = z.object(
@@ -56,10 +66,42 @@ export type PersonalDataAndDocumentsKyc = z.infer<
   typeof personalDataAndDocumentsKycSchema
 >
 
+export const personalDataAndDocumentsDetailedKycSchema = z.object(
+  {
+    firstName: z.string(),
+    middleName: z.string().optional(),
+    lastName: z.string(),
+    dateOfBirth: z.object({
+      day: z.string(),
+      month: z.string(),
+      year: z.string()
+    }),
+    address: z.object({
+      address1: z.string(),
+      address2: z.string().optional(),
+      isoCountryCode: z.string(),
+      isoRegionCode: z.string(),
+      city: z.string(),
+      postalCode: z.string().optional()
+    }),
+    phoneNumber: z.string(),
+    email: z.string(),
+    selfieDocument: z.string(),
+    identificationDocumentType: z.enum(["IDC", "PAS", "DL"]),
+    identificationDocumentFront: z.string(),
+    identificationDocumentBack: z.string().optional()
+  }
+)
+export type PersonalDataAndDocumentsDetailedKyc = z.infer<
+  typeof personalDataAndDocumentsDetailedKycSchema
+>
+
 export const kycSchemasSchema = z.object(
   {
     [kycSchemaSchema.enum.PersonalDataAndDocuments]:
       personalDataAndDocumentsKycSchema,
+    [kycSchemaSchema.enum.PersonalDataAndDocumentsDetailed]:
+      personalDataAndDocumentsDetailedKycSchema,
   },
   { description: 'kycSchemasSchema' },
 )

--- a/src/kyc.ts
+++ b/src/kyc.ts
@@ -23,7 +23,7 @@ export const kycStatusSchema = z.nativeEnum(KycStatus, {
 // When adding new schemas be sure to also update kycSchemasSchema
 export enum KycSchema {
   PersonalDataAndDocuments = 'PersonalDataAndDocuments',
-  PersonalDataAndDocumentsDetailed = 'PersonalDataAndDocumentsDetailed'
+  PersonalDataAndDocumentsDetailed = 'PersonalDataAndDocumentsDetailed',
 }
 export const kycSchemaSchema = z.nativeEnum(KycSchema, {
   description: 'kycSchemaSchema',
@@ -32,10 +32,10 @@ export const kycSchemaSchema = z.nativeEnum(KycSchema, {
 export enum KycDocumentType {
   IDC = 'IDC',
   PAS = 'PAS',
-  DL = 'DL'
+  DL = 'DL',
 }
 export const kycDocumentTypeSchema = z.nativeEnum(KycDocumentType, {
-  description: 'kycDocumentTypeSchema'
+  description: 'kycDocumentTypeSchema',
 })
 
 export const personalDataAndDocumentsKycSchema = z.object(
@@ -66,32 +66,30 @@ export type PersonalDataAndDocumentsKyc = z.infer<
   typeof personalDataAndDocumentsKycSchema
 >
 
-export const personalDataAndDocumentsDetailedKycSchema = z.object(
-  {
-    firstName: z.string(),
-    middleName: z.string().optional(),
-    lastName: z.string(),
-    dateOfBirth: z.object({
-      day: z.string(),
-      month: z.string(),
-      year: z.string()
-    }),
-    address: z.object({
-      address1: z.string(),
-      address2: z.string().optional(),
-      isoCountryCode: z.string(),
-      isoRegionCode: z.string(),
-      city: z.string(),
-      postalCode: z.string().optional()
-    }),
-    phoneNumber: z.string(),
-    email: z.string(),
-    selfieDocument: z.string(),
-    identificationDocumentType: z.enum(["IDC", "PAS", "DL"]),
-    identificationDocumentFront: z.string(),
-    identificationDocumentBack: z.string().optional()
-  }
-)
+export const personalDataAndDocumentsDetailedKycSchema = z.object({
+  firstName: z.string(),
+  middleName: z.string().optional(),
+  lastName: z.string(),
+  dateOfBirth: z.object({
+    day: z.string(),
+    month: z.string(),
+    year: z.string(),
+  }),
+  address: z.object({
+    address1: z.string(),
+    address2: z.string().optional(),
+    isoCountryCode: z.string(),
+    isoRegionCode: z.string(),
+    city: z.string(),
+    postalCode: z.string().optional(),
+  }),
+  phoneNumber: z.string(),
+  email: z.string(),
+  selfieDocument: z.string(),
+  identificationDocumentType: z.enum(['IDC', 'PAS', 'DL']),
+  identificationDocumentFront: z.string(),
+  identificationDocumentBack: z.string().optional(),
+})
 export type PersonalDataAndDocumentsDetailedKyc = z.infer<
   typeof personalDataAndDocumentsDetailedKycSchema
 >

--- a/src/kyc.ts
+++ b/src/kyc.ts
@@ -34,9 +34,12 @@ export enum IdentificationDocumentType {
   PAS = 'PAS',
   DL = 'DL',
 }
-export const IdentificationDocumentTypeSchema = z.nativeEnum(IdentificationDocumentType, {
-  description: 'IdentificationDocumentTypeSchema',
-})
+export const IdentificationDocumentTypeSchema = z.nativeEnum(
+  IdentificationDocumentType,
+  {
+    description: 'IdentificationDocumentTypeSchema',
+  },
+)
 
 export const personalDataAndDocumentsKycSchema = z.object(
   {
@@ -86,7 +89,7 @@ export const personalDataAndDocumentsDetailedKycSchema = z.object({
   phoneNumber: z.string(),
   email: z.string(),
   selfieDocument: z.string(),
-  identificationDocumentType: z.nativeEnum(IdentificationDocumentType),
+  identificationDocumentType: IdentificationDocumentTypeSchema,
   identificationDocumentFront: z.string(),
   identificationDocumentBack: z.string().optional(),
 })


### PR DESCRIPTION
According to revised spec with the new KYC schema `PersonalDataAndDocumentsDetailed`(https://github.com/fiatconnect/specification/blob/main/fiatconnect-api.md#9312-personaldataanddocumentsdetailed):

- Added new kyc schema
- Added new document type enum