### PR TITLE
feat: add PersonalDataAndDocumentsDetailed kyc schema

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -91,3 +91,6 @@ export enum CryptoType {
 export const cryptoTypeSchema = z.nativeEnum(CryptoType, {
   description: 'cryptoTypeSchema',
 })
+export const EMAIL_REGEX =
+  /* eslint-disable-next-line no-useless-escape */ // For some reason, eslint thinks the escaped \[ and /] are useless. they are indeed useful.
+  /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/ // credit to http://emailregex.com/

--- a/src/fiat-account.ts
+++ b/src/fiat-account.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { EMAIL_REGEX } from './common'
 
 /*
  * FiatConnect dynamic type definitions.
@@ -47,9 +48,6 @@ const requiredFiatAccountSchemaFieldsSchema = z.object({
   fiatAccountType: fiatAccountTypeSchema,
 })
 
-export const PIX_EMAIL_KEY_REGEX =
-  /* eslint-disable-next-line no-useless-escape */ // For some reason, eslint thinks the escaped \[ and /] are useless. they are indeed useful.
-  /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/ // credit to http://emailregex.com/
 export const PIX_CPF_KEY_REGEX = /^([0-9]{3}\.){2}[0-9]{3}[-]([0-9]{2})$/ // example: 000.000.000-00, see https://en.wikipedia.org/wiki/CPF_number
 export const PIX_PHONE_KEY_REGEX = /^[0-9]{11}$/
 export const PIX_RANDOM_KEY_REGEX = /^[a-zA-Z0-9-]{32}$/
@@ -67,7 +65,7 @@ export const pixAccountSchema = requiredFiatAccountSchemaFieldsSchema
     z
       .object({
         keyType: z.literal(PIXKeyTypeEnum.EMAIL),
-        key: z.string().regex(PIX_EMAIL_KEY_REGEX),
+        key: z.string().regex(EMAIL_REGEX),
       })
       .or(
         z.object({

--- a/src/kyc.ts
+++ b/src/kyc.ts
@@ -38,16 +38,22 @@ export enum IdentificationDocumentType {
   DL = 'DL',
 }
 
-// need [string, ...string[]] types to get zod enums to compile
-const documentsWithBack: [string, ...string[]] = [
-  IdentificationDocumentType.IDC,
-  IdentificationDocumentType.DL,
-]
-const documentsWithoutBack: [string, ...string[]] = Object.keys(
+// need nonempty array types to get zod enums to compile
+const documentsWithBack: [
   IdentificationDocumentType,
+  ...IdentificationDocumentType[],
+] = [IdentificationDocumentType.IDC, IdentificationDocumentType.DL]
+const documentsWithoutBack: [
+  IdentificationDocumentType,
+  ...IdentificationDocumentType[],
+] = (
+  Object.keys(IdentificationDocumentType) as [
+    IdentificationDocumentType,
+    ...IdentificationDocumentType[],
+  ]
 ).filter((idType) => !documentsWithBack.includes(idType)) as [
-  string,
-  ...string[],
+  IdentificationDocumentType,
+  ...IdentificationDocumentType[],
 ]
 
 const identificationDocumentTypeWithBackSchema = z.enum(documentsWithBack)

--- a/src/kyc.ts
+++ b/src/kyc.ts
@@ -98,7 +98,6 @@ export const personalDataAndDocumentsDetailedKycSchema =
       z.object({
         email: z.string().regex(EMAIL_REGEX),
         identificationDocumentFront: z.string(),
-        identificationDocumentType: identificationDocumentTypeSchema,
       }),
     )
     .and(

--- a/src/kyc.ts
+++ b/src/kyc.ts
@@ -38,13 +38,17 @@ export enum IdentificationDocumentType {
   DL = 'DL',
 }
 
-const documentsWithBack: IdentificationDocumentType[] = [
+// need [string, ...string[]] types to get zod enums to compile
+const documentsWithBack: [string, ...string[]] = [
   IdentificationDocumentType.IDC,
   IdentificationDocumentType.DL,
 ]
-const documentsWithoutBack = Object.keys(IdentificationDocumentType).filter(
-  (idType: IdentificationDocumentType) => !documentsWithBack.includes(idType),
-)
+const documentsWithoutBack: [string, ...string[]] = Object.keys(
+  IdentificationDocumentType,
+).filter((idType) => !documentsWithBack.includes(idType)) as [
+  string,
+  ...string[],
+]
 
 const identificationDocumentTypeWithBackSchema = z.enum(documentsWithBack)
 const identificationDocumentTypeWithoutBackSchema = z.enum(documentsWithoutBack)

--- a/src/kyc.ts
+++ b/src/kyc.ts
@@ -46,10 +46,8 @@ const documentsWithoutBack = Object.keys(IdentificationDocumentType).filter(
   (idType: IdentificationDocumentType) => !documentsWithBack.includes(idType),
 )
 
-const identificationDocumentTypeWithBackSchema =
-  z.enum(documentsWithBack)
-const identificationDocumentTypeWithoutBackSchema =
-  z.enum(documentsWithoutBack)
+const identificationDocumentTypeWithBackSchema = z.enum(documentsWithBack)
+const identificationDocumentTypeWithoutBackSchema = z.enum(documentsWithoutBack)
 export const identificationDocumentTypeSchema =
   identificationDocumentTypeWithBackSchema.or(
     identificationDocumentTypeWithoutBackSchema,

--- a/src/kyc.ts
+++ b/src/kyc.ts
@@ -38,7 +38,7 @@ export enum IdentificationDocumentType {
   DL = 'DL',
 }
 
-const documentsWithBack = [
+const documentsWithBack: IdentificationDocumentType[] = [
   IdentificationDocumentType.IDC,
   IdentificationDocumentType.DL,
 ]


### PR DESCRIPTION
similar to https://github.com/fiatconnect/fiatconnect-types/pull/121 but includes more semantics in the zod schemas, in particular:
- when the back of the document is required
- what the email should look like

also more DRY with the existing kyc schema