### PR TITLE
fix(deps): make zod peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     ],
     "preset": "conventionalcommits"
   },
-  "dependencies": {
+  "dependencies": {},
+  "peerDependencies": {
     "zod": "^3.22.2"
   }
 }


### PR DESCRIPTION
we had an issue recently with IHL where if we updated just zod or just FC types independently, the build broke. this ensures the projects using FC types use the same version of zod as FC types. some docs on this [here](https://classic.yarnpkg.com/lang/en/docs/dependency-types/#toc-peerdependencies)

still need to keep empty object for "dependencies" or zod is not installed, for some reason